### PR TITLE
Move error handling closer to source of error

### DIFF
--- a/tlsify.go
+++ b/tlsify.go
@@ -66,9 +66,8 @@ func main() {
 	log.Print("tlsify is running")
 
 	for {
-		clnt, err := srvr.Accept()
-
 		go func() {
+			clnt, err := srvr.Accept()
 			if err != nil {
 				log.Print(err)
 				return


### PR DESCRIPTION
This won't change anything in the programs behaviour, but in my opinion the program is slightly more readable this way. The creation of useless go routines is also avoided through this change.