### PR TITLE
Require exactly seven arguments and use exitcode 1 on misuse

### DIFF
--- a/tlsify.go
+++ b/tlsify.go
@@ -43,9 +43,9 @@ Usage: %s <type> <address> <type> <address> <certificate> <key>
 func main() {
 	fmt.Print(banner)
 
-	if len(os.Args) < 7 {
+	if len(os.Args) != 7 {
 		fmt.Printf(usage, os.Args[0])
-		return
+		os.Exit(1)
 	}
 
 	crt, err := tls.LoadX509KeyPair(os.Args[5], os.Args[6])


### PR DESCRIPTION
I think accepting unused arguments could be confusing and giving an exit code != 0 when the program is called with invalid parameters is common with UNIX tools (try e.g. `ls --misuse; echo "exit code: $?"`).